### PR TITLE
Add option in control panel to move cookie message to the bottom

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ Changelog
 0.7.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement option to move cookie message to the bottom
+  [nightmarebadger]
 
 
 0.7.4 (2014-03-31)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,3 +3,4 @@
 - Ralph Jacobs, fixes and improvements
 - Peter Uittenbroek, fixes and improvements
 - Mikel Larreategi, multilingual messages, implied consent and tests
+- Natan Žabkar (nightmarebadger), option to move cookie message to the bottom

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,4 +3,5 @@
 - Ralph Jacobs, fixes and improvements
 - Peter Uittenbroek, fixes and improvements
 - Mikel Larreategi, multilingual messages, implied consent and tests
-- Natan Žabkar (nightmarebadger), option to move cookie message to the bottom
+- Natan Žabkar (nightmarebadger), option to move cookie message to the bottom,
+  code cleanup

--- a/src/collective/cookiecuttr/Extensions/install.py
+++ b/src/collective/cookiecuttr/Extensions/install.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 
 
 def uninstall(portal):
     setup_tool = portal.portal_setup
-    setup_tool.runAllImportStepsFromProfile('profile-collective.cookiecuttr:uninstall')
+    setup_tool.runAllImportStepsFromProfile(
+        'profile-collective.cookiecuttr:uninstall')

--- a/src/collective/cookiecuttr/browser/viewlet.py
+++ b/src/collective/cookiecuttr/browser/viewlet.py
@@ -1,17 +1,15 @@
-from zope.component import getMultiAdapter
-from zope.interface import implements
-from zope.viewlet.interfaces import IViewlet
+# -*- coding: utf-8 -*-
 
-from Products.Five.browser import BrowserView
 from Products.CMFPlone.utils import safe_unicode
-
-from zope.component import getUtility
-from plone.registry.interfaces import IRegistry
-
+from Products.Five.browser import BrowserView
 from collective.cookiecuttr.interfaces import ICookieCuttrSettings
 from plone.app.layout.analytics.view import AnalyticsViewlet
-
 from plone.memoize.view import memoize
+from plone.registry.interfaces import IRegistry
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.interface import implements
+from zope.viewlet.interfaces import IViewlet
 
 
 class CookieCuttrViewlet(BrowserView):
@@ -34,7 +32,8 @@ class CookieCuttrViewlet(BrowserView):
 
     @memoize
     def language(self):
-        pps = getMultiAdapter((self.context, self.request),
+        pps = getMultiAdapter(
+            (self.context, self.request),
             name=u'plone_portal_state'
         )
         return pps.language()

--- a/src/collective/cookiecuttr/browser/viewlet.py
+++ b/src/collective/cookiecuttr/browser/viewlet.py
@@ -79,9 +79,13 @@ class CookieCuttrViewlet(BrowserView):
                 link = dic.get(self.language(), default).get('link')
                 text = dic.get(self.language(), default).get('text')
                 accept_button = dic.get(self.language(), default).get('accept')
+                location_bottom = 'false'
+                if self.settings.location_bottom:
+                    location_bottom = 'true'
                 snippet = safe_unicode(js_template % (link,
                                                       text,
-                                                      accept_button))
+                                                      accept_button,
+                                                      location_bottom))
                 return snippet
             else:
                 from logging import getLogger
@@ -117,7 +121,8 @@ js_template = """
                 $.cookieCuttr({cookieAnalytics: false,
                                cookiePolicyLink: "%s",
                                cookieMessage: "%s",
-                               cookieAcceptButtonText: "%s"
+                               cookieAcceptButtonText: "%s",
+                               cookieNotificationLocationBottom: %s
                                });
                 }
         })

--- a/src/collective/cookiecuttr/configure.zcml
+++ b/src/collective/cookiecuttr/configure.zcml
@@ -23,7 +23,7 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
- <genericsetup:upgradeStep
+  <genericsetup:upgradeStep
       title="Multilingual and implied consent"
       description="Use collective.z3cform.datagridfield to make it multilingual-aware and add implied consent option"
       source="*"

--- a/src/collective/cookiecuttr/configure.zcml
+++ b/src/collective/cookiecuttr/configure.zcml
@@ -31,6 +31,14 @@
       handler=".upgrades.upgrade_to_0002"
       profile="collective.cookiecuttr:default" />
 
+  <genericsetup:upgradeStep
+      title="Cookie message top or bottom location"
+      description="Add option to move cookie message to the bottom"
+      source="0002"
+      destination="0003"
+      handler=".upgrades.upgrade_from_0002_to_0003"
+      profile="collective.cookiecuttr:default" />
+
   <genericsetup:registerProfile
       name="uninstall"
       title="collective.cookiecuttr"

--- a/src/collective/cookiecuttr/interfaces.py
+++ b/src/collective/cookiecuttr/interfaces.py
@@ -74,6 +74,17 @@ class ICookieCuttrSettings(Interface):
                                   required=False,
                                   default=False,)
 
+    location_bottom = schema.Bool(
+        title=_(u"Show cookiecuttr at the bottom"),
+        description=_(
+            u"help_cookiecuttr_location_bottom",
+            default=u"If checked, the cookie message will be rendered at the "
+                     "bottom"
+            ),
+        required=False,
+        default=False,
+    )
+
     text = schema.List(
         title=_(u"Text to show your visitor"),
         required=False,

--- a/src/collective/cookiecuttr/interfaces.py
+++ b/src/collective/cookiecuttr/interfaces.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from collective.z3cform.datagridfield import DataGridFieldFactory
 from collective.z3cform.datagridfield.registry import DictRow
 from plone.autoform.directives import widget
@@ -57,22 +59,26 @@ class ICookieCuttrSettings(Interface):
     configuration registry and obtainable via plone.registry.
     """
 
-    cookiecuttr_enabled = schema.Bool(title=_(u"Enable CookieCuttr"),
-                                  description=_(u"help_cookiecuttr_enable",
-                                  default=u"Toggle this to enable"
-                                                " loading of the CookieCuttr"
-                                                " plugin."),
-                                  required=False,
-                                  default=False,)
+    cookiecuttr_enabled = schema.Bool(
+        title=_(u"Enable CookieCuttr"),
+        description=_(
+            u"help_cookiecuttr_enable",
+            default=u"Toggle this to enable loading of the CookieCuttr plugin."
+        ),
+        required=False,
+        default=False,
+    )
 
-    implied_consent = schema.Bool(title=_(u"Implied consent"),
-                                  description=_(u"help_cookiecuttr_inplied",
-                                  default=u"If enabled, the analytics viewlet"
-                                           " will be rendered even when the "
-                                           " message is not accepted"
-                                  ),
-                                  required=False,
-                                  default=False,)
+    implied_consent = schema.Bool(
+        title=_(u"Implied consent"),
+        description=_(
+            u"help_cookiecuttr_inplied",
+            default=u"If enabled, the analytics viewlet will be rendered even "
+                     "when the message is not accepted"
+        ),
+        required=False,
+        default=False,
+    )
 
     location_bottom = schema.Bool(
         title=_(u"Show cookiecuttr at the bottom"),
@@ -92,10 +98,11 @@ class ICookieCuttrSettings(Interface):
             title=u"Value",
             schema=ITextRowSchema
         ),
-        default=[dict(language=u'en', text=u"We use cookies."
-                 " <a href='{{cookiePolicyLink}}' "
-                 "title='read about our cookies'>"
-                 "Read everything</a>")],
+        default=[dict(
+            language=u'en',
+            text=u"We use cookies. <a href='{{cookiePolicyLink}}' "
+                 "title='read about our cookies'>Read everything</a>"
+         )],
     )
     widget(text=DataGridFieldFactory)
 

--- a/src/collective/cookiecuttr/profiles/default/metadata.xml
+++ b/src/collective/cookiecuttr/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>0002</version>
+  <version>0003</version>
   <dependencies>
       <dependency>profile-plone.app.registry:default</dependency>
       <dependency>profile-collective.z3cform.datagridfield:default</dependency>

--- a/src/collective/cookiecuttr/testing.py
+++ b/src/collective/cookiecuttr/testing.py
@@ -1,9 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import IntegrationTesting
 from plone.app.testing import applyProfile
-
 from zope.configuration import xmlconfig
+
 
 class CollectiveCookiecuttr(PloneSandboxLayer):
 
@@ -19,10 +21,9 @@ class CollectiveCookiecuttr(PloneSandboxLayer):
                        collective.cookiecuttr,
                        context=configurationContext)
 
-
-
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'collective.cookiecuttr:default')
+
 
 COLLECTIVE_COOKIECUTTR_FIXTURE = CollectiveCookiecuttr()
 COLLECTIVE_COOKIECUTTR_INTEGRATION_TESTING = \

--- a/src/collective/cookiecuttr/tests/test_controlpanel.py
+++ b/src/collective/cookiecuttr/tests/test_controlpanel.py
@@ -70,6 +70,7 @@ class RegistryTestCase(unittest.TestCase):
         self.assertTrue(hasattr(self.settings, 'text'))
         self.assertTrue(hasattr(self.settings, 'link'))
         self.assertTrue(hasattr(self.settings, 'accept_button'))
+        self.assertTrue(hasattr(self.settings, 'location_bottom'))
         # check default
         self.assertNotEqual(self.settings.accept_button, None)
 

--- a/src/collective/cookiecuttr/tests/test_controlpanel.py
+++ b/src/collective/cookiecuttr/tests/test_controlpanel.py
@@ -1,18 +1,15 @@
 # -*- coding: utf-8 -*-
 
-import unittest2 as unittest
-
-from zope.component import getMultiAdapter
-from zope.component import getUtility
-
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import logout
-from plone.app.testing import setRoles
-from plone.registry.interfaces import IRegistry
-
 from collective.cookiecuttr.interfaces import ICookieCuttrSettings
 from collective.cookiecuttr.testing import \
-                        COLLECTIVE_COOKIECUTTR_INTEGRATION_TESTING
+    COLLECTIVE_COOKIECUTTR_INTEGRATION_TESTING
+from plone.app.testing import logout
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+
+import unittest2 as unittest
 
 PROJECTNAME = 'collective.cookiecuttr'
 
@@ -35,9 +32,11 @@ class ControlPanelTestCase(unittest.TestCase):
     def test_controlpanel_view_is_protected(self):
         from AccessControl import Unauthorized
         logout()
-        self.assertRaises(Unauthorized,
-                          self.portal.restrictedTraverse,
-                         '@@cookiecuttr-settings')
+        self.assertRaises(
+            Unauthorized,
+            self.portal.restrictedTraverse,
+            '@@cookiecuttr-settings',
+        )
 
     def test_controlpanel_installed(self):
         actions = [a.getAction(self)['id']

--- a/src/collective/cookiecuttr/tests/test_install.py
+++ b/src/collective/cookiecuttr/tests/test_install.py
@@ -1,9 +1,9 @@
-import unittest2 as unittest
+# -*- coding: utf-8 -*-
 
 from Products.CMFCore.utils import getToolByName
-
 from collective.cookiecuttr.testing import\
     COLLECTIVE_COOKIECUTTR_INTEGRATION_TESTING
+import unittest2 as unittest
 
 
 class TestInstall(unittest.TestCase):
@@ -16,8 +16,8 @@ class TestInstall(unittest.TestCase):
         self.qi_tool = getToolByName(self.portal, 'portal_quickinstaller')
 
     def test_product_is_installed(self):
-        """ Validate that our products GS profile has been run and the product
-            installed
+        """Validate that our products GS profile has been run and the product
+           installed
         """
         pid = 'collective.cookiecuttr'
         installed = [p['id'] for p in self.qi_tool.listInstalledProducts()]

--- a/src/collective/cookiecuttr/tests/test_viewlet.py
+++ b/src/collective/cookiecuttr/tests/test_viewlet.py
@@ -1,22 +1,19 @@
-import unittest2 as unittest
+# -*- coding: utf-8 -*-
 
-from zope.component import queryMultiAdapter
-from zope.viewlet.interfaces import IViewletManager
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView as View
-
-# this time, we need to add an interface to the request
-from zope.interface import alsoProvides
-
-# The browserlayer
 from collective.cookiecuttr.interfaces import ICookieCuttr
 from collective.cookiecuttr.testing import\
     COLLECTIVE_COOKIECUTTR_INTEGRATION_TESTING
+from zope.component import queryMultiAdapter
+from zope.interface import alsoProvides
+from zope.viewlet.interfaces import IViewletManager
+
+import unittest2 as unittest
 
 
 class CookieCuttrViewletTestCase(unittest.TestCase):
-    """ test demonstrates that zcml registration variables worked properly
-    """
+    """Test demonstrates that zcml registration variables worked properly"""
     layer = COLLECTIVE_COOKIECUTTR_INTEGRATION_TESTING
 
     def setUp(self):
@@ -27,9 +24,9 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         pprops.site_properties.webstats_js = self.webstats_js
 
     def test_viewlet_is_not_installed(self):
-        """ looking up and updating the manager should not list our viewlet
-            when our browserlayer is not applied, eq. when our product is not
-            installed.
+        """Looking up and updating the manager should not list our viewlet
+           when our browserlayer is not applied, eq. when our product is not
+           installed.
         """
         request = self.app.REQUEST
         context = self.portal
@@ -37,13 +34,19 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         view = View(context, request)
 
         manager_name = 'plone.htmlhead'
-        manager = queryMultiAdapter((context, request, view), IViewletManager, manager_name, default=None)
+        manager = queryMultiAdapter(
+            (context, request, view),
+            IViewletManager,
+            manager_name,
+            default=None,
+        )
 
         self.failUnless(manager)
 
         manager.update()
 
-        my_viewlet = [v for v in manager.viewlets if v.__name__ == 'collective.cookiecuttr']
+        my_viewlet = [v for v in manager.viewlets
+                      if v.__name__ == 'collective.cookiecuttr']
 
         self.failUnlessEqual(len(my_viewlet), 0)
 
@@ -55,7 +58,12 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         # Get the contents of the analytics viewlet or return a string
         # explaining what went wrong..
         manager_name = 'plone.portalfooter'
-        manager = queryMultiAdapter((context, request, view), IViewletManager, manager_name, default=None)
+        manager = queryMultiAdapter(
+            (context, request, view),
+            IViewletManager,
+            manager_name,
+            default=None,
+        )
         if manager is None:
             return 'No viewlet manager %s found.' % manager_name
         manager.update()
@@ -67,8 +75,7 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         return analytics_viewlet[0].render()
 
     def test_viewlet_is_present(self):
-        """ looking up and updating the manager should list our viewlet
-        """
+        """Looking up and updating the manager should list our viewlet"""
         # our viewlet is registered for a browser layer.  Browser layers
         # are applied to the request during traversal in the publisher.  We
         # need to do the same thing manually here
@@ -83,7 +90,12 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         manager_name = 'plone.htmlhead'
 
         # viewlet managers are found by Multi-Adapter lookup
-        manager = queryMultiAdapter((context, request, view), IViewletManager, manager_name, default=None)
+        manager = queryMultiAdapter(
+            (context, request, view),
+            IViewletManager,
+            manager_name,
+            default=None,
+        )
 
         self.failUnless(manager)
 
@@ -93,7 +105,8 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         # now our viewlet should be in the list of viewlets for the manager
         # we can verify this by looking for a viewlet with the name we used
         # to register the viewlet in zcml
-        my_viewlet = [v for v in manager.viewlets if v.__name__ == 'collective.cookiecuttr']
+        my_viewlet = [v for v in manager.viewlets
+                      if v.__name__ == 'collective.cookiecuttr']
 
         self.failUnlessEqual(len(my_viewlet), 1)
 
@@ -102,7 +115,7 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         self.assertEqual(analytics, self.webstats_js)
 
     def test_viewlet_cookiecuttr_disabled(self):
-        """ looking up and updating the manager should list our viewlet
+        """Looking up and updating the manager should list our viewlet
 
         But when disabled it should be empty.
         """
@@ -119,7 +132,12 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         manager_name = 'plone.htmlhead'
 
         # viewlet managers are found by Multi-Adapter lookup
-        manager = queryMultiAdapter((context, request, view), IViewletManager, manager_name, default=None)
+        manager = queryMultiAdapter(
+            (context, request, view),
+            IViewletManager,
+            manager_name,
+            default=None,
+        )
 
         self.failUnless(manager)
 
@@ -129,7 +147,8 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         # now our viewlet should be in the list of viewlets for the manager
         # we can verify this by looking for a viewlet with the name we used
         # to register the viewlet in zcml
-        my_viewlet = [v for v in manager.viewlets if v.__name__ == 'collective.cookiecuttr']
+        my_viewlet = [v for v in manager.viewlets
+                      if v.__name__ == 'collective.cookiecuttr']
 
         self.failUnlessEqual(len(my_viewlet), 1)
         self.failUnlessEqual(my_viewlet[0].render(), '')
@@ -139,7 +158,7 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         self.assertEqual(analytics, self.webstats_js)
 
     def test_viewlet_cookiecuttr_enabled(self):
-        """ looking up and updating the manager should list our viewlet
+        """Looking up and updating the manager should list our viewlet
 
         It is enabled so it should be filled.
         """
@@ -156,7 +175,12 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         manager_name = 'plone.htmlhead'
 
         # viewlet managers are found by Multi-Adapter lookup
-        manager = queryMultiAdapter((context, request, view), IViewletManager, manager_name, default=None)
+        manager = queryMultiAdapter(
+            (context, request, view),
+            IViewletManager,
+            manager_name,
+            default=None,
+        )
 
         self.failUnless(manager)
 
@@ -166,21 +190,39 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         # now our viewlet should be in the list of viewlets for the manager
         # we can verify this by looking for a viewlet with the name we used
         # to register the viewlet in zcml
-        my_viewlet = [v for v in manager.viewlets if v.__name__ == 'collective.cookiecuttr']
+        my_viewlet = [v for v in manager.viewlets
+                      if v.__name__ == 'collective.cookiecuttr']
 
         self.failUnlessEqual(len(my_viewlet), 1)
 
         my_viewlet[0].settings.cookiecuttr_enabled = True
 
-        self.failUnlessEqual(my_viewlet[0].render(), u'\n<script type="text/javascript">\n\n    (function($) {\n        $(document).ready(function () {\n            if($.cookieCuttr) {\n                $.cookieCuttr({cookieAnalytics: false,\n                               cookiePolicyLink: " ",\n                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",\n                               cookieAcceptButtonText: "Accept cookies",\n                               cookieNotificationLocationBottom: false\n                               });\n                }\n        })\n    })(jQuery);\n</script>\n\n')
+        expected = u"""
+<script type="text/javascript">
+
+    (function($) {
+        $(document).ready(function () {
+            if($.cookieCuttr) {
+                $.cookieCuttr({cookieAnalytics: false,
+                               cookiePolicyLink: " ",
+                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",
+                               cookieAcceptButtonText: "Accept cookies",
+                               cookieNotificationLocationBottom: false
+                               });
+                }
+        })
+    })(jQuery);
+</script>
+
+"""
+        self.failUnlessEqual(my_viewlet[0].render(), expected)
 
         # The analytics viewlet should be there and show nothing.
         analytics = self.get_analytics_viewlet_contents(context, request, view)
         self.assertEqual(analytics, '')
 
     def test_viewlet_analytics(self):
-        """ looking up and updating the manager should list our viewlet
-        """
+        """Looking up and updating the manager should list our viewlet"""
         # our viewlet is registered for a browser layer.  Browser layers
         # are applied to the request during traversal in the publisher.  We
         # need to do the same thing manually here
@@ -194,7 +236,12 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         manager_name = 'plone.htmlhead'
 
         # viewlet managers are found by Multi-Adapter lookup
-        manager = queryMultiAdapter((context, request, view), IViewletManager, manager_name, default=None)
+        manager = queryMultiAdapter(
+            (context, request, view),
+            IViewletManager,
+            manager_name,
+            default=None,
+        )
 
         self.failUnless(manager)
 
@@ -204,12 +251,31 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         # now our viewlet should be in the list of viewlets for the manager
         # we can verify this by looking for a viewlet with the name we used
         # to register the viewlet in zcml
-        my_viewlet = [v for v in manager.viewlets if v.__name__ == 'collective.cookiecuttr']
+        my_viewlet = [v for v in manager.viewlets
+                      if v.__name__ == 'collective.cookiecuttr']
 
         self.failUnlessEqual(len(my_viewlet), 1)
 
         my_viewlet[0].settings.cookiecuttr_enabled = True
-        self.failUnlessEqual(my_viewlet[0].render(), u'\n<script type="text/javascript">\n\n    (function($) {\n        $(document).ready(function () {\n            if($.cookieCuttr) {\n                $.cookieCuttr({cookieAnalytics: false,\n                               cookiePolicyLink: " ",\n                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",\n                               cookieAcceptButtonText: "Accept cookies",\n                               cookieNotificationLocationBottom: false\n                               });\n                }\n        })\n    })(jQuery);\n</script>\n\n')
+        expected = u"""
+<script type="text/javascript">
+
+    (function($) {
+        $(document).ready(function () {
+            if($.cookieCuttr) {
+                $.cookieCuttr({cookieAnalytics: false,
+                               cookiePolicyLink: " ",
+                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",
+                               cookieAcceptButtonText: "Accept cookies",
+                               cookieNotificationLocationBottom: false
+                               });
+                }
+        })
+    })(jQuery);
+</script>
+
+"""
+        self.failUnlessEqual(my_viewlet[0].render(), expected)
 
         # The analytics viewlet should be there and be empty.
         analytics = self.get_analytics_viewlet_contents(context, request, view)
@@ -239,8 +305,7 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         self.failUnlessEqual(analytics, self.webstats_js)
 
     def test_viewlet_implied_consent(self):
-        """ check the implied consent setting
-        """
+        """Check the implied consent setting"""
         # our viewlet is registered for a browser layer.  Browser layers
         # are applied to the request during traversal in the publisher.  We
         # need to do the same thing manually here
@@ -254,7 +319,12 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         manager_name = 'plone.htmlhead'
 
         # viewlet managers are found by Multi-Adapter lookup
-        manager = queryMultiAdapter((context, request, view), IViewletManager, manager_name, default=None)
+        manager = queryMultiAdapter(
+            (context, request, view),
+            IViewletManager,
+            manager_name,
+            default=None,
+        )
 
         self.failUnless(manager)
 
@@ -264,12 +334,31 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         # now our viewlet should be in the list of viewlets for the manager
         # we can verify this by looking for a viewlet with the name we used
         # to register the viewlet in zcml
-        my_viewlet = [v for v in manager.viewlets if v.__name__ == 'collective.cookiecuttr']
+        my_viewlet = [v for v in manager.viewlets
+                      if v.__name__ == 'collective.cookiecuttr']
 
         self.failUnlessEqual(len(my_viewlet), 1)
 
         my_viewlet[0].settings.cookiecuttr_enabled = True
-        self.failUnlessEqual(my_viewlet[0].render(), u'\n<script type="text/javascript">\n\n    (function($) {\n        $(document).ready(function () {\n            if($.cookieCuttr) {\n                $.cookieCuttr({cookieAnalytics: false,\n                               cookiePolicyLink: " ",\n                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",\n                               cookieAcceptButtonText: "Accept cookies",\n                               cookieNotificationLocationBottom: false\n                               });\n                }\n        })\n    })(jQuery);\n</script>\n\n')
+        expected = u"""
+<script type="text/javascript">
+
+    (function($) {
+        $(document).ready(function () {
+            if($.cookieCuttr) {
+                $.cookieCuttr({cookieAnalytics: false,
+                               cookiePolicyLink: " ",
+                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",
+                               cookieAcceptButtonText: "Accept cookies",
+                               cookieNotificationLocationBottom: false
+                               });
+                }
+        })
+    })(jQuery);
+</script>
+
+"""
+        self.failUnlessEqual(my_viewlet[0].render(), expected)
 
         footer_manager = queryMultiAdapter((context, request, view),
                                            IViewletManager,
@@ -278,10 +367,12 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
 
         footer_manager.update()
 
-        analytics_viewlet = [v for v in footer_manager.viewlets if v.__name__ == 'plone.analytics'][0]
+        analytics_viewlet = [v for v in footer_manager.viewlets
+                             if v.__name__ == 'plone.analytics'][0]
 
         # Set something for the analytics viewlet
-        self.portal.portal_properties.site_properties.webstats_js = "analytics test"
+        self.portal.portal_properties.site_properties.webstats_js = (
+            "analytics test")
 
         # CookieCuttr enabled, implied_consent enabled, user has no cookie,
         # analytics viewlet is rendered
@@ -293,7 +384,6 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
 
     def test_viewlet_location_bottom(self):
         """Check the location_bottom setting."""
-
         # our viewlet is registered for a browser layer.  Browser layers
         # are applied to the request during traversal in the publisher.  We
         # need to do the same thing manually here

--- a/src/collective/cookiecuttr/tests/test_viewlet.py
+++ b/src/collective/cookiecuttr/tests/test_viewlet.py
@@ -172,7 +172,7 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
 
         my_viewlet[0].settings.cookiecuttr_enabled = True
 
-        self.failUnlessEqual(my_viewlet[0].render(), u'\n<script type="text/javascript">\n\n    (function($) {\n        $(document).ready(function () {\n            if($.cookieCuttr) {\n                $.cookieCuttr({cookieAnalytics: false,\n                               cookiePolicyLink: " ",\n                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",\n                               cookieAcceptButtonText: "Accept cookies"\n                               });\n                }\n        })\n    })(jQuery);\n</script>\n\n')
+        self.failUnlessEqual(my_viewlet[0].render(), u'\n<script type="text/javascript">\n\n    (function($) {\n        $(document).ready(function () {\n            if($.cookieCuttr) {\n                $.cookieCuttr({cookieAnalytics: false,\n                               cookiePolicyLink: " ",\n                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",\n                               cookieAcceptButtonText: "Accept cookies",\n                               cookieNotificationLocationBottom: false\n                               });\n                }\n        })\n    })(jQuery);\n</script>\n\n')
 
         # The analytics viewlet should be there and show nothing.
         analytics = self.get_analytics_viewlet_contents(context, request, view)
@@ -209,7 +209,7 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         self.failUnlessEqual(len(my_viewlet), 1)
 
         my_viewlet[0].settings.cookiecuttr_enabled = True
-        self.failUnlessEqual(my_viewlet[0].render(), u'\n<script type="text/javascript">\n\n    (function($) {\n        $(document).ready(function () {\n            if($.cookieCuttr) {\n                $.cookieCuttr({cookieAnalytics: false,\n                               cookiePolicyLink: " ",\n                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",\n                               cookieAcceptButtonText: "Accept cookies"\n                               });\n                }\n        })\n    })(jQuery);\n</script>\n\n')
+        self.failUnlessEqual(my_viewlet[0].render(), u'\n<script type="text/javascript">\n\n    (function($) {\n        $(document).ready(function () {\n            if($.cookieCuttr) {\n                $.cookieCuttr({cookieAnalytics: false,\n                               cookiePolicyLink: " ",\n                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",\n                               cookieAcceptButtonText: "Accept cookies",\n                               cookieNotificationLocationBottom: false\n                               });\n                }\n        })\n    })(jQuery);\n</script>\n\n')
 
         # The analytics viewlet should be there and be empty.
         analytics = self.get_analytics_viewlet_contents(context, request, view)
@@ -269,7 +269,7 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         self.failUnlessEqual(len(my_viewlet), 1)
 
         my_viewlet[0].settings.cookiecuttr_enabled = True
-        self.failUnlessEqual(my_viewlet[0].render(), u'\n<script type="text/javascript">\n\n    (function($) {\n        $(document).ready(function () {\n            if($.cookieCuttr) {\n                $.cookieCuttr({cookieAnalytics: false,\n                               cookiePolicyLink: " ",\n                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",\n                               cookieAcceptButtonText: "Accept cookies"\n                               });\n                }\n        })\n    })(jQuery);\n</script>\n\n')
+        self.failUnlessEqual(my_viewlet[0].render(), u'\n<script type="text/javascript">\n\n    (function($) {\n        $(document).ready(function () {\n            if($.cookieCuttr) {\n                $.cookieCuttr({cookieAnalytics: false,\n                               cookiePolicyLink: " ",\n                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",\n                               cookieAcceptButtonText: "Accept cookies",\n                               cookieNotificationLocationBottom: false\n                               });\n                }\n        })\n    })(jQuery);\n</script>\n\n')
 
         footer_manager = queryMultiAdapter((context, request, view),
                                            IViewletManager,
@@ -291,3 +291,80 @@ class CookieCuttrViewletTestCase(unittest.TestCase):
         self.failUnlessEqual(analytics_viewlet.render(), "analytics test")
         analytics = self.get_analytics_viewlet_contents(context, request, view)
 
+    def test_viewlet_location_bottom(self):
+        """Check the location_bottom setting."""
+
+        # our viewlet is registered for a browser layer.  Browser layers
+        # are applied to the request during traversal in the publisher.  We
+        # need to do the same thing manually here
+        request = self.app.REQUEST
+        context = self.portal
+        alsoProvides(request, ICookieCuttr)
+
+        view = View(context, request)
+
+        # finally, you need the name of the manager you want to find
+        manager_name = 'plone.htmlhead'
+
+        # viewlet managers are found by Multi-Adapter lookup
+        manager = queryMultiAdapter(
+            (context, request, view),
+            IViewletManager,
+            manager_name,
+            default=None,
+        )
+
+        self.failUnless(manager)
+
+        # calling update() on a manager causes it to set up its viewlets
+        manager.update()
+
+        # now our viewlet should be in the list of viewlets for the manager
+        # we can verify this by looking for a viewlet with the name we used
+        # to register the viewlet in zcml
+        my_viewlet = [v for v in manager.viewlets
+                      if v.__name__ == 'collective.cookiecuttr']
+
+        self.failUnlessEqual(len(my_viewlet), 1)
+
+        my_viewlet[0].settings.cookiecuttr_enabled = True
+        expected = u"""
+<script type="text/javascript">
+
+    (function($) {
+        $(document).ready(function () {
+            if($.cookieCuttr) {
+                $.cookieCuttr({cookieAnalytics: false,
+                               cookiePolicyLink: " ",
+                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",
+                               cookieAcceptButtonText: "Accept cookies",
+                               cookieNotificationLocationBottom: false
+                               });
+                }
+        })
+    })(jQuery);
+</script>
+
+"""
+        self.failUnlessEqual(my_viewlet[0].render(), expected)
+        my_viewlet[0].settings.location_bottom = True
+
+        expected = u"""
+<script type="text/javascript">
+
+    (function($) {
+        $(document).ready(function () {
+            if($.cookieCuttr) {
+                $.cookieCuttr({cookieAnalytics: false,
+                               cookiePolicyLink: " ",
+                               cookieMessage: "We use cookies. <a href=\'{{cookiePolicyLink}}\' title=\'read about our cookies\'>Read everything</a>",
+                               cookieAcceptButtonText: "Accept cookies",
+                               cookieNotificationLocationBottom: true
+                               });
+                }
+        })
+    })(jQuery);
+</script>
+
+"""
+        self.failUnlessEqual(my_viewlet[0].render(), expected)

--- a/src/collective/cookiecuttr/upgrades.py
+++ b/src/collective/cookiecuttr/upgrades.py
@@ -48,3 +48,16 @@ def upgrade_to_0002(context, logger=None):
     portal_setup.runAllImportStepsFromProfile(DEPENDENCY)
 
     logger.info('Done')
+
+
+def upgrade_from_0002_to_0003(context, logger=None):
+    """Add option to move cookie message to the bottom to the control panel."""
+
+    if logger is None:
+        logger = logging.getLogger('collective.cookiecuttr')
+
+    # Re-import plone.app.registry
+    portal_setup = getToolByName(context, 'portal_setup')
+    portal_setup.runImportStepFromProfile(PROFILE_ID, 'plone.app.registry')
+
+    logger.info('Successfully upgraded from 0002 to 0003')

--- a/src/collective/cookiecuttr/upgrades.py
+++ b/src/collective/cookiecuttr/upgrades.py
@@ -1,6 +1,8 @@
-from plone.registry.interfaces import IRegistry
+# -*- coding: utf-8 -*-
+
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
+from plone.registry.interfaces import IRegistry
 from zope.component import queryUtility
 
 import logging
@@ -20,9 +22,18 @@ def upgrade_to_0002(context, logger=None):
 
     # Get the existing values
     registry = queryUtility(IRegistry)
-    text = registry.get('collective.cookiecuttr.interfaces.ICookieCuttrSettings.text', u' ')
-    link = registry.get('collective.cookiecuttr.interfaces.ICookieCuttrSettings.link', u' ')
-    accept = registry.get('collective.cookiecuttr.interfaces.ICookieCuttrSettings.accept_button', u' ')
+    text = registry.get(
+        'collective.cookiecuttr.interfaces.ICookieCuttrSettings.text',
+        u' '
+    )
+    link = registry.get(
+        'collective.cookiecuttr.interfaces.ICookieCuttrSettings.link',
+        u' '
+    )
+    accept = registry.get(
+        'collective.cookiecuttr.interfaces.ICookieCuttrSettings.accept_button',
+        u' '
+    )
 
     if not text:
         text = u' '


### PR DESCRIPTION
cookiecuttr.js includes an option to move the cookie message to the bottom ('cookieNotificationLocationBottom'). I have simply added a checkbox to the control panel that controls this option, so users can quickly and easily change the location of their message between top and bottom. 

I have fixed the tests my change broke and added a new one to test the new functionality. One test fails ('test_viewlet_is_not_installed'), but it failed before my changes too. 

Since I added to the control panel, an upgrade step was also needed. 

I have also cleaned up the code a bit (sticking to the Plone API conventions http://ploneapi.readthedocs.org/en/latest/contribute/conventions.html, but I might have missed something) - if you want I can open this as a separate PR and remove the cleanup commit from this one. 