### PR TITLE
Avoid useless reload of the page

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ Changelog
 0.7.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid useless reload of the page : cookies are working without it
+  [laulaz]
 
 
 0.7.6 (2018-09-07)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,7 +11,8 @@ Changelog
 0.7.6 (2018-09-07)
 ------------------
 
-- Nothing changed yet.
+- Avoid displaying message multiple times
+  [laulaz]
 
 
 0.7.5 (2016-03-11)

--- a/src/collective/cookiecuttr/static/jquery.cookiecuttr.js
+++ b/src/collective/cookiecuttr/static/jquery.cookiecuttr.js
@@ -255,10 +255,7 @@
                     path: '/'
                 });
             }
-            $(".cc-cookies").fadeOut(function () {
-                // reload page to activate cookies
-                location.reload();
-            });
+            $(".cc-cookies").fadeOut();
         });
         //reset cookies
         $('a.cc-cookie-reset').click(function (f) {
@@ -269,10 +266,7 @@
             $.cookie("cc_cookie_decline", null, {
                 path: '/'
             });
-            $(".cc-cookies").fadeOut(function () {
-                // reload page to activate cookies
-                location.reload();
-            });
+            $(".cc-cookies").fadeOut();
         });
         //cookie error accept
         $('.cc-cookies-error a.cc-cookie-accept').click(function (g) {
@@ -284,8 +278,6 @@
             $.cookie("cc_cookie_decline", null, {
                 path: '/'
             });
-            // reload page to activate cookies
-            location.reload();
         });
     };
 })(jQuery);


### PR DESCRIPTION
We had a UX issue with page reloading after cookie acceptation.
After reading the code, we don't understand why the page had to be reloaded to activate cookies.
It's working fine without that reload.

Can you please merge this PR or explain the edge case you were wanting to handle with that reload ?